### PR TITLE
only look for character arguments to loadNamespace and requireNamespace

### DIFF
--- a/R/code.R
+++ b/R/code.R
@@ -37,7 +37,11 @@ find_pkgs_rec <- function(x) {
     }
   } else if (is_call(x, c("requireNamespace", "loadNamespace"))) {
     x <- call_standardise(x, env = baseenv())
-    char_or_sym(x$package)
+    if (is.character(x$package)) {
+      x$package
+    } else {
+      character()
+    }
   } else {
     flat_map_chr(as.list(x), find_pkgs_rec)
   }

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -11,8 +11,8 @@ test_that("finds explicit package loading calls", {
   expect_equal(req_code(library(x)), "x")
   expect_equal(req_code(library("x")), "x")
   expect_equal(req_code(require(x)), "x")
-  expect_equal(req_code(requireNamespace(x)), "x")
-  expect_equal(req_code(loadNamespace(x)), "x")
+  expect_equal(req_code(requireNamespace("x")), "x")
+  expect_equal(req_code(loadNamespace("x")), "x")
 })
 
 test_that("handle character.only correctly", {


### PR DESCRIPTION
Unless I'm much mistaken, loadNamespace and requireNamespace only take character "package" arguments. This PR ensures that calling `req_file()` on a file containing:

```
f <- function (package) {
  loadNamespace(package, lib.loc = package_dir, partial = partial)
}
```

will not return a requirement named "package".
